### PR TITLE
Adding the compare attribute to let teams compare on email address

### DIFF
--- a/.env.example.aad
+++ b/.env.example.aad
@@ -16,6 +16,10 @@ PRIVATE_KEY_PATH=.ssh/team-sync.pem
 ## Active Directory = LDAP
 ## OpenLDAP = LDAP
 USER_DIRECTORY=AAD
+## Attribute to compare users with
+## username or email
+USER_ATTRIBUTE=username
+
 
 #######################
 ## Azure AD Settings ##

--- a/.env.example.aad
+++ b/.env.example.aad
@@ -18,7 +18,7 @@ PRIVATE_KEY_PATH=.ssh/team-sync.pem
 USER_DIRECTORY=AAD
 ## Attribute to compare users with
 ## username or email
-USER_ATTRIBUTE=username
+USER_SYNC_ATTRIBUTE=username
 
 
 #######################

--- a/.env.example.ldap
+++ b/.env.example.ldap
@@ -16,6 +16,9 @@ PRIVATE_KEY_PATH=.ssh/team-sync.pem
 ## Active Directory = LDAP
 ## OpenLDAP = LDAP
 USER_DIRECTORY=LDAP
+## Attribute to compare users with
+## username or email
+USER_ATTRIBUTE=username
 
 ###################
 ## LDAP Settings ##

--- a/.env.example.ldap
+++ b/.env.example.ldap
@@ -18,7 +18,7 @@ PRIVATE_KEY_PATH=.ssh/team-sync.pem
 USER_DIRECTORY=LDAP
 ## Attribute to compare users with
 ## username or email
-USER_ATTRIBUTE=username
+USER_SYNC_ATTRIBUTE=username
 
 ###################
 ## LDAP Settings ##

--- a/.env.example.okta
+++ b/.env.example.okta
@@ -19,7 +19,7 @@ PRIVATE_KEY_PATH=.ssh/team-sync.pem
 USER_DIRECTORY=OKTA
 ## Attribute to compare users with
 ## username or email
-USER_ATTRIBUTE=username
+USER_SYNC_ATTRIBUTE=username
 
 
 ###################

--- a/.env.example.okta
+++ b/.env.example.okta
@@ -17,6 +17,10 @@ PRIVATE_KEY_PATH=.ssh/team-sync.pem
 ## OpenLDAP = LDAP
 ## Okta = OKTA
 USER_DIRECTORY=OKTA
+## Attribute to compare users with
+## username or email
+USER_ATTRIBUTE=username
+
 
 ###################
 ## Okta Settings ##

--- a/.env.example.onelogin
+++ b/.env.example.onelogin
@@ -18,6 +18,10 @@ PRIVATE_KEY_PATH=.ssh/team-sync.pem
 ## Okta = OKTA
 ## OneLogin = ONELOGIN
 USER_DIRECTORY=ONELOGIN
+## Attribute to compare users with
+## username or email
+USER_ATTRIBUTE=username
+
 
 #######################
 ## OneLogin Settings ##

--- a/.env.example.onelogin
+++ b/.env.example.onelogin
@@ -20,7 +20,7 @@ PRIVATE_KEY_PATH=.ssh/team-sync.pem
 USER_DIRECTORY=ONELOGIN
 ## Attribute to compare users with
 ## username or email
-USER_ATTRIBUTE=username
+USER_SYNC_ATTRIBUTE=username
 
 
 #######################

--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ This utility provides the following functionality:
 
 | Category | Attribute | Permission |
 | --- | --- | --- |
+| Repository permissions | `Issues` | `Read & write` |
+| Repositroy permissions | `Metadata` | `Read-only` |
 | Organization permissions | `Members` | `Read & write` |
 | User permissions | `Email addresses` | `Read-only` |
-| Repository permissions | `Issues` | `Read & write` |
-| Repostiroy permissions | `Metadata` | `Read-only` |
 
 #### Events
 

--- a/app.py
+++ b/app.py
@@ -15,7 +15,7 @@ from githubapp import (
     CRON_INTERVAL,
     TEST_MODE,
     ADD_MEMBER,
-    COMPARE_ATTRIBUTE,
+    USER_SYNC_ATTRIBUTE,
 )
 
 app = Flask(__name__)

--- a/app.py
+++ b/app.py
@@ -69,7 +69,7 @@ def sync_team(client=None, owner=None, team_id=None, slug=None):
         client=client, owner=owner, team_id=team_id, attribute=USER_SYNC_ATTRIBUTE
     )
     compare = compare_members(
-        group=directory_members, team=team_members, attribute=COMPARE_ATTRIBUTE
+        group=directory_members, team=team_members, attribute=USER_SYNC_ATTRIBUTE
     )
     if TEST_MODE:
         print("Skipping execution due to TEST_MODE...")

--- a/app.py
+++ b/app.py
@@ -66,7 +66,7 @@ def sync_team(client=None, owner=None, team_id=None, slug=None):
         directory_members = []
         print(e)
     team_members = github_team_members(
-        client=client, owner=owner, team_id=team_id, attribute=COMPARE_ATTRIBUTE
+        client=client, owner=owner, team_id=team_id, attribute=USER_SYNC_ATTRIBUTE
     )
     compare = compare_members(
         group=directory_members, team=team_members, attribute=COMPARE_ATTRIBUTE

--- a/app.py
+++ b/app.py
@@ -9,7 +9,14 @@ from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
 from flask import Flask
 
-from githubapp import GitHubApp, DirectoryClient, CRON_INTERVAL, TEST_MODE, ADD_MEMBER
+from githubapp import (
+    GitHubApp,
+    DirectoryClient,
+    CRON_INTERVAL,
+    TEST_MODE,
+    ADD_MEMBER,
+    COMPARE_ATTRIBUTE,
+)
 
 app = Flask(__name__)
 github_app = GitHubApp(app)
@@ -59,10 +66,10 @@ def sync_team(client=None, owner=None, team_id=None, slug=None):
         directory_members = []
         print(e)
     team_members = github_team_members(
-        client=client, owner=owner, team_id=team_id, attribute="username"
+        client=client, owner=owner, team_id=team_id, attribute=COMPARE_ATTRIBUTE
     )
     compare = compare_members(
-        group=directory_members, team=team_members, attribute="username"
+        group=directory_members, team=team_members, attribute=COMPARE_ATTRIBUTE
     )
     if TEST_MODE:
         print("Skipping execution due to TEST_MODE...")

--- a/githubapp/__init__.py
+++ b/githubapp/__init__.py
@@ -39,4 +39,4 @@ except ValueError as e:
     TEST_MODE = False
 # Check if should add member to organization
 ADD_MEMBER = strtobool(os.environ.get("ADD_MEMBER", "False"))
-COMPARE_ATTRIBUTE = os.environ.get("COMPARE_ATTRIBUTE", "username").lower()
+USER_SYNC_ATTRIBUTE = os.environ.get("USER_SYNC_ATTRIBUTE", "username").lower()

--- a/githubapp/__init__.py
+++ b/githubapp/__init__.py
@@ -39,3 +39,4 @@ except ValueError as e:
     TEST_MODE = False
 # Check if should add member to organization
 ADD_MEMBER = strtobool(os.environ.get("ADD_MEMBER", "False"))
+COMPARE_ATTRIBUTE = os.environ.get("COMPARE_ATTRIBUTE", "username").lower()


### PR DESCRIPTION
Adding config option to allow for comparing users on their email rather than username.
Also re-arranging the README a bit so it follows the order in the app config pages.

closes #11 