### PR TITLE
Set .env defaults

### DIFF
--- a/githubapp/__init__.py
+++ b/githubapp/__init__.py
@@ -28,8 +28,8 @@ if rootlogger.level == logging.NOTSET:
 
 CRON_INTERVAL = os.environ.get("SYNC_SCHEDULE", "0 * * * *")
 CHANGE_THRESHOLD = os.environ.get('CHANGE_THRESHOLD', 25)
-REPO_FOR_ISSUES = os.environ.get('REPO_FOR_ISSUES')
-ISSUE_ASSIGNEE = os.environ.get('ISSUE_ASSIGNEE')
+REPO_FOR_ISSUES = os.environ.get('REPO_FOR_ISSUES', '')
+ISSUE_ASSIGNEE = os.environ.get('ISSUE_ASSIGNEE', '')
 OPEN_ISSUE_ON_FAILURE = strtobool(os.environ.get('OPEN_ISSUE_ON_FAILURE', 'False'))
 
 try:

--- a/githubapp/__init__.py
+++ b/githubapp/__init__.py
@@ -27,10 +27,11 @@ if rootlogger.level == logging.NOTSET:
     rootlogger.setLevel(logging.WARN)
 
 CRON_INTERVAL = os.environ.get("SYNC_SCHEDULE", "0 * * * *")
-# CHANGE_THRESHOLD = os.environ.get('CHANGE_THRESHOLD', 25)
-# REPO_FOR_ISSUES = os.environ.get('REPO_FOR_ISSUES')
-# ISSUE_ASSIGNEE = os.environ.get('ISSUE_ASSIGNEE')
-# OPEN_ISSUE_ON_FAILURE = strtobool(os.environ.get('OPEN_ISSUE_ON_FAILURE', 'False'))
+CHANGE_THRESHOLD = os.environ.get('CHANGE_THRESHOLD', 25)
+REPO_FOR_ISSUES = os.environ.get('REPO_FOR_ISSUES')
+ISSUE_ASSIGNEE = os.environ.get('ISSUE_ASSIGNEE')
+OPEN_ISSUE_ON_FAILURE = strtobool(os.environ.get('OPEN_ISSUE_ON_FAILURE', 'False'))
+
 try:
     TEST_MODE = strtobool(os.environ.get("TEST_MODE", "False"))
 except ValueError as e:

--- a/githubapp/__init__.py
+++ b/githubapp/__init__.py
@@ -27,10 +27,10 @@ if rootlogger.level == logging.NOTSET:
     rootlogger.setLevel(logging.WARN)
 
 CRON_INTERVAL = os.environ.get("SYNC_SCHEDULE", "0 * * * *")
-CHANGE_THRESHOLD = os.environ.get('CHANGE_THRESHOLD', 25)
-REPO_FOR_ISSUES = os.environ.get('REPO_FOR_ISSUES', '')
-ISSUE_ASSIGNEE = os.environ.get('ISSUE_ASSIGNEE', '')
-OPEN_ISSUE_ON_FAILURE = strtobool(os.environ.get('OPEN_ISSUE_ON_FAILURE', 'False'))
+CHANGE_THRESHOLD = os.environ.get("CHANGE_THRESHOLD", 25)
+REPO_FOR_ISSUES = os.environ.get("REPO_FOR_ISSUES", "")
+ISSUE_ASSIGNEE = os.environ.get("ISSUE_ASSIGNEE", "")
+OPEN_ISSUE_ON_FAILURE = strtobool(os.environ.get("OPEN_ISSUE_ON_FAILURE", "False"))
 
 try:
     TEST_MODE = strtobool(os.environ.get("TEST_MODE", "False"))


### PR DESCRIPTION
The app fails to start if some of the environment keys are missing. This sets those variables to their defaults