### PR TITLE
C/ignore ssl

### DIFF
--- a/.env.example.aad
+++ b/.env.example.aad
@@ -12,7 +12,7 @@ PRIVATE_KEY_PATH=.ssh/team-sync.pem
 #GHE_HOST=github.example.com
 ## Uncomment if you are using a self-signed certificate on GitHub Enterprise.
 ## Defaults to False.
-#IGNORE_SSL=true
+#VERIFY_SSL=False
 
 ## User directory to sync GitHub teams from
 ## Azure AD = AAD

--- a/.env.example.aad
+++ b/.env.example.aad
@@ -10,6 +10,9 @@ PRIVATE_KEY_PATH=.ssh/team-sync.pem
 ## Uncomment the following line and use your own GitHub Enterprise
 ## instance if this will not be used on https://github.com
 #GHE_HOST=github.example.com
+## Uncomment if you are using a self-signed certificate on GitHub Enterprise.
+## Defaults to False.
+#IGNORE_SSL=true
 
 ## User directory to sync GitHub teams from
 ## Azure AD = AAD
@@ -69,7 +72,7 @@ SYNC_SCHEDULE=0 * * * *
 ## Default: false
 #TEST_MODE=false
 ## Automatically add users missing from the organization
-ADD_MEMBER=false 
+ADD_MEMBER=false
 
 
 ####################

--- a/.env.example.ldap
+++ b/.env.example.ldap
@@ -12,7 +12,7 @@ PRIVATE_KEY_PATH=.ssh/team-sync.pem
 #GHE_HOST=github.example.com
 ## Uncomment if you are using a self-signed certificate on GitHub Enterprise.
 ## Defaults to False.
-#IGNORE_SSL=true
+#VERIFY_SSL=False
 
 ## User directory to sync GitHub teams from
 ## Azure AD = AAD

--- a/.env.example.ldap
+++ b/.env.example.ldap
@@ -10,6 +10,9 @@ PRIVATE_KEY_PATH=.ssh/team-sync.pem
 ## Uncomment the following line and use your own GitHub Enterprise
 ## instance if this will not be used on https://github.com
 #GHE_HOST=github.example.com
+## Uncomment if you are using a self-signed certificate on GitHub Enterprise.
+## Defaults to False.
+#IGNORE_SSL=true
 
 ## User directory to sync GitHub teams from
 ## Azure AD = AAD
@@ -71,7 +74,7 @@ SYNC_SCHEDULE=0 * * * *
 ## Default: false
 #TEST_MODE=false
 ## Automatically add users missing from the organization
-ADD_MEMBER=false 
+ADD_MEMBER=false
 
 ####################
 ## Flask Settings ##

--- a/.env.example.okta
+++ b/.env.example.okta
@@ -12,7 +12,7 @@ PRIVATE_KEY_PATH=.ssh/team-sync.pem
 #GHE_HOST=github.example.com
 ## Uncomment if you are using a self-signed certificate on GitHub Enterprise.
 ## Defaults to False.
-#IGNORE_SSL=true
+#VERIFY_SSL=False
 
 ## User directory to sync GitHub teams from
 ## Azure AD = AAD

--- a/.env.example.okta
+++ b/.env.example.okta
@@ -10,6 +10,9 @@ PRIVATE_KEY_PATH=.ssh/team-sync.pem
 ## Uncomment the following line and use your own GitHub Enterprise
 ## instance if this will not be used on https://github.com
 #GHE_HOST=github.example.com
+## Uncomment if you are using a self-signed certificate on GitHub Enterprise.
+## Defaults to False.
+#IGNORE_SSL=true
 
 ## User directory to sync GitHub teams from
 ## Azure AD = AAD
@@ -54,7 +57,7 @@ SYNC_SCHEDULE=0 * * * *
 ## Default: false
 #TEST_MODE=false
 ## Automatically add users missing from the organization
-ADD_MEMBER=false 
+ADD_MEMBER=false
 
 ####################
 ## Flask Settings ##

--- a/.env.example.onelogin
+++ b/.env.example.onelogin
@@ -12,7 +12,7 @@ PRIVATE_KEY_PATH=.ssh/team-sync.pem
 #GHE_HOST=github.example.com
 ## Uncomment if you are using a self-signed certificate on GitHub Enterprise.
 ## Defaults to False.
-#IGNORE_SSL=true
+#VERIFY_SSL=False
 
 ## User directory to sync GitHub teams from
 ## Azure AD = AAD

--- a/.env.example.onelogin
+++ b/.env.example.onelogin
@@ -10,6 +10,9 @@ PRIVATE_KEY_PATH=.ssh/team-sync.pem
 ## Uncomment the following line and use your own GitHub Enterprise
 ## instance if this will not be used on https://github.com
 #GHE_HOST=github.example.com
+## Uncomment if you are using a self-signed certificate on GitHub Enterprise.
+## Defaults to False.
+#IGNORE_SSL=true
 
 ## User directory to sync GitHub teams from
 ## Azure AD = AAD
@@ -56,7 +59,7 @@ SYNC_SCHEDULE=0 * * * *
 ## Default: false
 #TEST_MODE=false
 ## Automatically add users missing from the organization
-ADD_MEMBER=false 
+ADD_MEMBER=false
 
 ####################
 ## Flask Settings ##

--- a/githubapp/core.py
+++ b/githubapp/core.py
@@ -37,7 +37,9 @@ class GitHubApp(object):
         app.config["GITHUBAPP_SECRET"] = os.environ["WEBHOOK_SECRET"]
         if "GHE_HOST" in os.environ:
             app.config["GITHUBAPP_URL"] = "https://{}".format(os.environ["GHE_HOST"])
-            app.config["IGNORE_SSL"] = os.environ.get("IGNORE_SSL", False)
+            app.config["IGNORE_SSL"] = bool(
+                distutils.util.strtobool(os.environ.get("IGNORE_SSL", "false"))
+            )
         with open(os.environ["PRIVATE_KEY_PATH"], "rb") as key_file:
             app.config["GITHUBAPP_KEY"] = key_file.read()
 

--- a/githubapp/core.py
+++ b/githubapp/core.py
@@ -36,8 +36,7 @@ class GitHubApp(object):
         app.config["GITHUBAPP_ID"] = int(os.environ["APP_ID"])
         app.config["GITHUBAPP_SECRET"] = os.environ["WEBHOOK_SECRET"]
         if "GHE_HOST" in os.environ:
-            app.config["GITHUBAPP_URL"] = "https://{}".format(
-                    os.environ["GHE_HOST"])
+            app.config["GITHUBAPP_URL"] = "https://{}".format(os.environ["GHE_HOST"])
             app.config["IGNORE_SSL"] = os.environ.get("IGNORE_SSL", False)
         with open(os.environ["PRIVATE_KEY_PATH"], "rb") as key_file:
             app.config["GITHUBAPP_KEY"] = key_file.read()
@@ -74,19 +73,18 @@ class GitHubApp(object):
             Default: '/'
         """
         self.load_env(app)
-        required_settings = ["GITHUBAPP_ID",
-                "GITHUBAPP_KEY", "GITHUBAPP_SECRET"]
+        required_settings = ["GITHUBAPP_ID", "GITHUBAPP_KEY", "GITHUBAPP_SECRET"]
         for setting in required_settings:
             if not app.config.get(setting):
                 raise RuntimeError(
-                        "Flask-GitHubApp requires the '%s' config var to be set" % setting
-                        )
+                    "Flask-GitHubApp requires the '%s' config var to be set" % setting
+                )
 
         app.add_url_rule(
-                app.config.get("GITHUBAPP_ROUTE", "/"),
-                view_func=self._flask_view_func,
-                methods=["POST"],
-                )
+            app.config.get("GITHUBAPP_ROUTE", "/"),
+            view_func=self._flask_view_func,
+            methods=["POST"],
+        )
 
     @property
     def id(self):
@@ -114,7 +112,10 @@ class GitHubApp(object):
     def client(self):
         """Unauthenticated GitHub client"""
         if current_app.config.get("GITHUBAPP_URL"):
-            return GitHubEnterprise(current_app.config["GITHUBAPP_URL"], verify=current_app.config["IGNORE_SSL"])
+            return GitHubEnterprise(
+                current_app.config["GITHUBAPP_URL"],
+                verify=current_app.config["IGNORE_SSL"],
+            )
         return GitHub()
 
     @property
@@ -124,8 +125,8 @@ class GitHubApp(object):
             return request.json
 
         raise RuntimeError(
-                "Payload is only available in the context of a GitHub hook request"
-                )
+            "Payload is only available in the context of a GitHub hook request"
+        )
 
     @property
     def installation_client(self):
@@ -135,8 +136,8 @@ class GitHubApp(object):
             if not hasattr(ctx, "githubapp_installation"):
                 client = self.client
                 client.login_as_app_installation(
-                        self.key, self.id, self.payload["installation"]["id"]
-                        )
+                    self.key, self.id, self.payload["installation"]["id"]
+                )
                 ctx.githubapp_installation = client
             return ctx.githubapp_installation
 
@@ -173,8 +174,7 @@ class GitHubApp(object):
         if ctx is not None:
             if not hasattr(ctx, "githubapp_installation"):
                 client = self.client
-                client.login_as_app_installation(
-                        self.key, self.id, installation_id)
+                client.login_as_app_installation(self.key, self.id, installation_id)
                 ctx.githubapp_installation = client
             return ctx.githubapp_installation
 

--- a/githubapp/core.py
+++ b/githubapp/core.py
@@ -4,7 +4,7 @@ Flask extension for rapid GitHub app development
 import os.path
 import hmac
 import logging
-import distuils
+import distutils
 
 from flask import abort, current_app, jsonify, request, _app_ctx_stack
 from github3 import GitHub, GitHubEnterprise

--- a/githubapp/core.py
+++ b/githubapp/core.py
@@ -36,7 +36,9 @@ class GitHubApp(object):
         app.config["GITHUBAPP_ID"] = int(os.environ["APP_ID"])
         app.config["GITHUBAPP_SECRET"] = os.environ["WEBHOOK_SECRET"]
         if "GHE_HOST" in os.environ:
-            app.config["GITHUBAPP_URL"] = "https://{}".format(os.environ["GHE_HOST"])
+            app.config["GITHUBAPP_URL"] = "https://{}".format(
+                    os.environ["GHE_HOST"])
+            app.config["IGNORE_SSL"] = os.environ.get("IGNORE_SSL", False)
         with open(os.environ["PRIVATE_KEY_PATH"], "rb") as key_file:
             app.config["GITHUBAPP_KEY"] = key_file.read()
 
@@ -72,18 +74,19 @@ class GitHubApp(object):
             Default: '/'
         """
         self.load_env(app)
-        required_settings = ["GITHUBAPP_ID", "GITHUBAPP_KEY", "GITHUBAPP_SECRET"]
+        required_settings = ["GITHUBAPP_ID",
+                "GITHUBAPP_KEY", "GITHUBAPP_SECRET"]
         for setting in required_settings:
             if not app.config.get(setting):
                 raise RuntimeError(
-                    "Flask-GitHubApp requires the '%s' config var to be set" % setting
-                )
+                        "Flask-GitHubApp requires the '%s' config var to be set" % setting
+                        )
 
         app.add_url_rule(
-            app.config.get("GITHUBAPP_ROUTE", "/"),
-            view_func=self._flask_view_func,
-            methods=["POST"],
-        )
+                app.config.get("GITHUBAPP_ROUTE", "/"),
+                view_func=self._flask_view_func,
+                methods=["POST"],
+                )
 
     @property
     def id(self):
@@ -111,7 +114,7 @@ class GitHubApp(object):
     def client(self):
         """Unauthenticated GitHub client"""
         if current_app.config.get("GITHUBAPP_URL"):
-            return GitHubEnterprise(current_app.config["GITHUBAPP_URL"])
+            return GitHubEnterprise(current_app.config["GITHUBAPP_URL"], verify=current_app.config["IGNORE_SSL"])
         return GitHub()
 
     @property
@@ -121,8 +124,8 @@ class GitHubApp(object):
             return request.json
 
         raise RuntimeError(
-            "Payload is only available in the context of a GitHub hook request"
-        )
+                "Payload is only available in the context of a GitHub hook request"
+                )
 
     @property
     def installation_client(self):
@@ -132,8 +135,8 @@ class GitHubApp(object):
             if not hasattr(ctx, "githubapp_installation"):
                 client = self.client
                 client.login_as_app_installation(
-                    self.key, self.id, self.payload["installation"]["id"]
-                )
+                        self.key, self.id, self.payload["installation"]["id"]
+                        )
                 ctx.githubapp_installation = client
             return ctx.githubapp_installation
 
@@ -170,7 +173,8 @@ class GitHubApp(object):
         if ctx is not None:
             if not hasattr(ctx, "githubapp_installation"):
                 client = self.client
-                client.login_as_app_installation(self.key, self.id, installation_id)
+                client.login_as_app_installation(
+                        self.key, self.id, installation_id)
                 ctx.githubapp_installation = client
             return ctx.githubapp_installation
 

--- a/githubapp/core.py
+++ b/githubapp/core.py
@@ -4,6 +4,7 @@ Flask extension for rapid GitHub app development
 import os.path
 import hmac
 import logging
+import distuils
 
 from flask import abort, current_app, jsonify, request, _app_ctx_stack
 from github3 import GitHub, GitHubEnterprise

--- a/githubapp/core.py
+++ b/githubapp/core.py
@@ -38,8 +38,8 @@ class GitHubApp(object):
         app.config["GITHUBAPP_SECRET"] = os.environ["WEBHOOK_SECRET"]
         if "GHE_HOST" in os.environ:
             app.config["GITHUBAPP_URL"] = "https://{}".format(os.environ["GHE_HOST"])
-            app.config["IGNORE_SSL"] = bool(
-                distutils.util.strtobool(os.environ.get("IGNORE_SSL", "false"))
+            app.config["VERIFY_SSL"] = bool(
+                distutils.util.strtobool(os.environ.get("VERIFY_SSL", "false"))
             )
         with open(os.environ["PRIVATE_KEY_PATH"], "rb") as key_file:
             app.config["GITHUBAPP_KEY"] = key_file.read()
@@ -117,7 +117,7 @@ class GitHubApp(object):
         if current_app.config.get("GITHUBAPP_URL"):
             return GitHubEnterprise(
                 current_app.config["GITHUBAPP_URL"],
-                verify=current_app.config["IGNORE_SSL"],
+                verify=current_app.config["VERIFY_SSL"],
             )
         return GitHub()
 


### PR DESCRIPTION
Adding a config option to ignore ssl certificates if they are self-signed or expired, should be used for testing only.