### PR TITLE
Fix #109. Use explicit match condition

### DIFF
--- a/githubapp/azuread.py
+++ b/githubapp/azuread.py
@@ -73,7 +73,7 @@ class AzureAD:
         # url encode the group name
         group_name = requests.utils.quote(group_name)
         graph_data = requests.get(  # Use token to call downstream service
-            f"{self.AZURE_API_ENDPOINT}/groups?$filter=startswith(displayName,'{group_name}')",
+            f"{self.AZURE_API_ENDPOINT}/groups?$filter=displayName eq '{group_name}'",
             headers={"Authorization": f"Bearer {token}"},
         ).json()
         # print("Graph API call result: %s" % json.dumps(graph_data, indent=2))


### PR DESCRIPTION
This PR attempts to fix #109: use explicit `eq` filter condition over `startswith`