### PR TITLE
Enable OAuth authentication method for Okta

### DIFF
--- a/.env.example.okta
+++ b/.env.example.okta
@@ -30,11 +30,27 @@ USER_SYNC_ATTRIBUTE=username
 ###################
 ## Your organizations Okta URL
 OKTA_ORG_URL=https://example.okta.com
-## The bot's access token
-OKTA_ACCESS_TOKEN=asdfghkjliptojkjsj00294759
 ## The attribute which corresponds to the GitHub Username
 ## NOTE: This cannot be an email address
 OKTA_USERNAME_ATTRIBUTE=github_username
+
+###############################
+## Okta token authentication ##
+###############################
+## The bot's access token
+OKTA_ACCESS_TOKEN=asdfghkjliptojkjsj00294759
+
+###############################
+## Okta OAuth authentication ##
+###############################
+## Auth method switch
+OKTA_AUTH_METHOD=oauth
+## Okta OIDC app client ID
+OKTA_CLIENT_ID=abcdefghijkl
+## Okta OIDC auth scopes
+OKTA_SCOPES=okta.users.read
+## Okta OIDC app private key (JWK format)
+OKTA_PRIVATE_KEY='{"kty": "RSA", ...}'
 
 #########################
 ## Additional settings ##

--- a/README.md
+++ b/README.md
@@ -168,8 +168,16 @@ AZURE_USER_IS_UPN=true
 ### Sample `.env` for Okta
 ```env
 OKTA_ORG_URL=https://example.okta.com
-OKTA_ACCESS_TOKEN=asdfghkjliptojkjsj00294759
 OKTA_USERNAME_ATTRIBUTE=github_username
+
+# token login
+OKTA_ACCESS_TOKEN=asdfghkjliptojkjsj00294759
+
+# OAuth login
+OKTA_AUTH_METHOD=oauth
+OKTA_CLIENT_ID=abcdefghijkl
+OKTA_SCOPES=okta.users.read
+OKTA_PRIVATE_KEY='{"kty": "RSA", ...}'
 ```
 
 ### Sample `.env` for OneLogin

--- a/githubapp/okta.py
+++ b/githubapp/okta.py
@@ -10,10 +10,15 @@ LOG = logging.getLogger(__name__)
 class Okta:
     def __init__(self):
         self.USERNAME_ATTRIBUTE = os.environ.get("OKTA_USERNAME_ATTRIBUTE", "login")
-        config = {
-            "orgUrl": os.environ["OKTA_ORG_URL"],
-            "token": os.environ["OKTA_ACCESS_TOKEN"],
-        }
+        auth_method = os.environ.get("OKTA_AUTH_METHOD", "token")
+        config = {"orgUrl": os.environ["OKTA_ORG_URL"]}
+        if auth_method == "oauth":
+            config["authorizationMode"] = "PrivateKey"
+            config["clientId"] = os.environ["OKTA_CLIENT_ID"]
+            config["scopes"] = os.environ["OKTA_SCOPES"]
+            config["privateKey"] = os.environ["OKTA_PRIVATE_KEY"]
+        else:
+            config["token"] = os.environ["OKTA_ACCESS_TOKEN"]
         self.client = OktaClient(config)
 
     def get_group_members(self, group_name=None):


### PR DESCRIPTION
In addition to API tokens, support the auth
using an OAuth 2.0 service app credentials.

Based on [okta-sdk-python docs](https://github.com/okta/okta-sdk-python#oauth-20).