### PR TITLE
Pass Okta OAuth scopes in correct format

### DIFF
--- a/.env.example.okta
+++ b/.env.example.okta
@@ -48,7 +48,7 @@ OKTA_AUTH_METHOD=oauth
 ## Okta OIDC app client ID
 OKTA_CLIENT_ID=abcdefghijkl
 ## Okta OIDC auth scopes
-OKTA_SCOPES=okta.users.read
+OKTA_SCOPES='okta.users.read okta.groups.read'
 ## Okta OIDC app private key (JWK format)
 OKTA_PRIVATE_KEY='{"kty": "RSA", ...}'
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ OKTA_ACCESS_TOKEN=asdfghkjliptojkjsj00294759
 # OAuth login
 OKTA_AUTH_METHOD=oauth
 OKTA_CLIENT_ID=abcdefghijkl
-OKTA_SCOPES=okta.users.read
+OKTA_SCOPES='okta.users.read okta.groups.read'
 OKTA_PRIVATE_KEY='{"kty": "RSA", ...}'
 ```
 

--- a/githubapp/okta.py
+++ b/githubapp/okta.py
@@ -15,7 +15,7 @@ class Okta:
         if auth_method == "oauth":
             config["authorizationMode"] = "PrivateKey"
             config["clientId"] = os.environ["OKTA_CLIENT_ID"]
-            config["scopes"] = os.environ["OKTA_SCOPES"]
+            config["scopes"] = os.environ["OKTA_SCOPES"].split(' ')
             config["privateKey"] = os.environ["OKTA_PRIVATE_KEY"]
         else:
             config["token"] = os.environ["OKTA_ACCESS_TOKEN"]


### PR DESCRIPTION
The Okta SDK [expects scopes to be a list](https://github.com/okta/okta-sdk-python/blob/0ae9eaa42c/okta/oauth.py#L47).

Follow-up for #117.