### PR TITLE
Improve error handling in Okta module

### DIFF
--- a/githubapp/okta.py
+++ b/githubapp/okta.py
@@ -73,5 +73,9 @@ class Okta:
                     }
                 )
             except AttributeError as e:
-                print(f"{user.links['self']['href']}: {e}")
+                if user.links:
+                    user_info = user.links['self']['href']
+                else:
+                    user_info = user
+                print(f"User {user_info}: {e}")
         return member_list


### PR DESCRIPTION
The original error handling logic was
sometimes throwing errors due to log:
```
File "githubapp/okta.py", line 76, in get_group_members
    print(f"{user.links['self']['href']}: {e}")
TypeError: 'NoneType' object is not subscriptable
```