### PR TITLE
Add support for ignoring GitHub users

### DIFF
--- a/syncmap.yml.example
+++ b/syncmap.yml.example
@@ -4,3 +4,8 @@ mapping:
     directory: ldap super users
   - github: demo-team-2
     directory: another-group
+
+ignore_users:
+  - userA
+  - userB
+  - userC


### PR DESCRIPTION
In some cases, a user may be added to
teams even without directory account.
Add support to keep the user in team.