### PR TITLE
Tidy up dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ LABEL maintainer="GitHub Services <services@github.com>"
 
 ARG TZ='UTC'
 
-ENV DEFAULT_TZ ${TZ}
+ENV DEFAULT_TZ=${TZ}
 
 RUN apk add --no-cache \
         libxml2-dev \
@@ -32,4 +32,4 @@ RUN pipenv install
 
 COPY . /opt/github-team-sync
 
-CMD pipenv run flask run
+CMD ["pipenv", "run", "flask", "run"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,11 +23,13 @@ RUN apk add --no-cache \
 # Fix the warning where no timezone is specified
 RUN cp /usr/share/zoneinfo/${DEFAULT_TZ} /etc/localtime
 
-COPY . /opt/github-team-sync
-WORKDIR /opt/github-team-sync
-
 RUN pip install --no-cache-dir --upgrade pipenv
 
+WORKDIR /opt/github-team-sync
+COPY Pipfile Pipfile.lock .
+
 RUN pipenv install
+
+COPY . /opt/github-team-sync
 
 CMD pipenv run flask run

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,18 +8,6 @@ ARG TZ='UTC'
 
 ENV DEFAULT_TZ=${TZ}
 
-RUN apk add --no-cache \
-        libxml2-dev \
-        libxslt-dev \
-        python3-dev \
-        make \
-        gcc \
-        libffi-dev \
-        build-base \
-        openssl-dev \
-        cargo \
-        tzdata
-
 # Fix the warning where no timezone is specified
 RUN cp /usr/share/zoneinfo/${DEFAULT_TZ} /etc/localtime
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,6 @@ ARG TZ='UTC'
 
 ENV DEFAULT_TZ ${TZ}
 
-COPY . /opt/github-team-sync
-WORKDIR /opt/github-team-sync
-
 RUN apk add --no-cache \
         libxml2-dev \
         libxslt-dev \
@@ -25,6 +22,9 @@ RUN apk add --no-cache \
 
 # Fix the warning where no timezone is specified
 RUN cp /usr/share/zoneinfo/${DEFAULT_TZ} /etc/localtime
+
+COPY . /opt/github-team-sync
+WORKDIR /opt/github-team-sync
 
 RUN pip install --no-cache-dir --upgrade pipenv
 


### PR DESCRIPTION
This PR rearranges & tidies up the Dockerfile to achieve a few things:
 - Avoids longer rebuilds on code change by copying the pipfile in, running install, then copying the code in
 - Significantly reduces the image size by removing unnecessary development libraries
 - Fixes up a few warnings thrown by buildx

Testing locally, a fresh build now takes 7 seconds less (31s vs 38s) & uses less than 25% of the space (296MB vs 1.38GB)